### PR TITLE
[improve] submit button no longer resets by default on drop-in ui creation

### DIFF
--- a/src/assetbundles/dropinui/dist/js/DropinUi.js
+++ b/src/assetbundles/dropinui/dist/js/DropinUi.js
@@ -96,7 +96,6 @@
 						}
 						return;
 					}
-					reset($submit);
 
 					if (dropinInstance.isPaymentMethodRequestable()) {
 						reset($submit);


### PR DESCRIPTION
The removed line was taking precedence over the conditionals directly below it. So now the submit payment button for the Drop-in UI stays disabled until the user can actually submit payment.