### PR TITLE
fix deprecation warning for locale in drop-in ui template

### DIFF
--- a/src/templates/paymentForms/dropin-ui.twig
+++ b/src/templates/paymentForms/dropin-ui.twig
@@ -5,5 +5,5 @@
 <input type="hidden" name="currency" value="{{ order.paymentCurrency }}">
 <input type="hidden" name="email" value="{{ order.email }}">
 <input type="hidden" name="address" value="{{ gateway.format3DSAddress(order)|json_encode }}">
-<div data-id="dropInUi" {{ gateway.testMode ? 'data-sandbox' }} data-name="{{ storeName ?? siteName }}" data-locale="{{ craft.i18n.getLocaleData().id|replace('-','_') }}" data-subscription="{{ subscription }}" data-threedsecure="{{ threeDSecure }}" data-manage="{{ manage }}"></div>
+<div data-id="dropInUi" {{ gateway.testMode ? 'data-sandbox' }} data-name="{{ storeName ?? siteName }}" data-locale="{{ craft.app.locale|replace('-','_') }}" data-subscription="{{ subscription }}" data-threedsecure="{{ threeDSecure }}" data-manage="{{ manage }}"></div>
 


### PR DESCRIPTION
This PR fixes the following deprecation warning

![Screenshot 2019-09-25 16 09 28](https://user-images.githubusercontent.com/2531682/65646169-02c13c80-dfaf-11e9-8d87-0d2c33a5c16c.png)
