### PR TITLE
Making payment and currency default to default merchant account if no…

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -308,9 +308,13 @@ class Gateway extends BaseGateway
 			} elseif ($form->token) {
 				$data['paymentMethodToken'] = $form->token;
 			}
-			if (isset($this->merchantAccountId[$transaction->currency])) {
-				$data['merchantAccountId'] = $this->merchantAccountId[$transaction->currency];
-			}			
+            if (isset($this->merchantAccountId[$transaction->paymentCurrency]) && !empty($this->merchantAccountId[$transaction->paymentCurrency])) {
+                $data['merchantAccountId'] = $this->merchantAccountId[$transaction->paymentCurrency];
+                $data['amount'] = $transaction->paymentAmount;
+            } else {
+                $data['merchantAccountId'] = "";
+                $data['amount'] = $transaction->amount;
+            }
 			if($form->type != "PayPalAccount") {
 				if($order->billingAddress || $order->shippingAddress) {
 					$data['billing'] = $this->_formatAddress($order->billingAddress ?: $order->shippingAddress);


### PR DESCRIPTION
… merchant accountId is set

When no merchant account is set or doesn't exist for a currency, the gateway should still be able to make the payment. 

This defaults the payment to the default gateway converted back to the default currency for when merchant id doesn't exist or isn't set