### PR TITLE
Wrap every call to $this->merchantAccountId in Craft::parseEnv()

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -173,7 +173,7 @@ class Gateway extends BaseGateway
         if ($paymentForm && $paymentForm->hasProperty('nonce') && $paymentForm->nonce) {
             $request['token'] = $paymentForm->nonce;
         }
-        $request['merchantAccountId'] = $this->merchantAccountId[$request['currency']];
+        $request['merchantAccountId'] = Craft::parseEnv($this->merchantAccountId[$request['currency']]);
         //Craft::dd($request);
     }*/
 
@@ -313,7 +313,7 @@ class Gateway extends BaseGateway
                 $data['paymentMethodToken'] = $form->token;
             }
             if (isset($this->merchantAccountId[$transaction->currency]) && !empty($this->merchantAccountId[$transaction->currency])) {
-				$data['merchantAccountId'] = $this->merchantAccountId[$transaction->currency];
+				$data['merchantAccountId'] = Craft::parseEnv($this->merchantAccountId[$transaction->currency]);
 			} else {
 				$data['merchantAccountId'] = "";
 				$data['amount'] = $transaction->amount;
@@ -526,7 +526,7 @@ class Gateway extends BaseGateway
             'paymentMethodToken' => $source->token,
             'planId' => $plan->reference,
 			'price' => $plan->price,
-			'merchantAccountId' => $this->merchantAccountId[$plan->getCurrency()],
+			'merchantAccountId' => Craft::parseEnv($this->merchantAccountId[$plan->getCurrency()]),
 		];
 
         $response = $this->createSubscription($data);


### PR DESCRIPTION
This is required when the merchant account ID fields are set to environment variables (and it seems like the intent is to support that).