### PR TITLE
Ensure all exceptions thrown by purchase() have a message

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -333,7 +333,11 @@ class Gateway extends BaseGateway
 
             return new PaymentResponse($result);
         } catch (\Exception $exception) {
-            throw $exception;
+            $message = $exception->getMessage();
+            if ($message) {
+                throw new PaymentException($message);
+            }
+            throw new PaymentException('The payment could not be processed (' . get_class($exception) . ')');
         }
     }
 


### PR DESCRIPTION
I had a really hard time debugging failed transactions because most exceptions thrown by the Braintree PHP library don't have messages, see this issue: https://github.com/braintree/braintree_php/issues/250

This PR ensures that the exceptions that will be caught by Commerce in the `commerce/payments/pay` controller action have messages, so they are properly returned to the front-end.