### PR TITLE
Add support for trial days per subscription.

### DIFF
--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -664,6 +664,12 @@ class Gateway extends BaseGateway
 			),
 		];
 
+		if ($parameters->trialDays > 0) {
+			$data['trialPeriod'] = 1;
+			$data['trialDurationUnit'] = 'day';
+			$data['trialDuration'] = $parameters->trialDays;
+		}
+
 		$response = $this->createSubscription($data);
 
 		if (!$response->success) {


### PR DESCRIPTION
I have some instances where I need to specify the length of a trial on individual subscription basis, instead of using trials at the plan level. I believe this is all that's required, and did exactly what I was looking for on the Braintree side.