### PR TITLE
Fixed error when attempting to use Google Pay

### DIFF
--- a/src/assetbundles/dropinui/dist/js/DropinUi.js
+++ b/src/assetbundles/dropinui/dist/js/DropinUi.js
@@ -81,13 +81,13 @@
 					};
 
 					options.googlePay = {
-						displayName: $dropinUi.data('name'),
-						paymentRequest: {
-							total: {
-								label: $dropinUi.data('name'),
-								amount: amount
-							}
-						}
+						merchantId: $dropinUi.data('googleId'),
+                        googlePayVersion: 2,
+                        transactionInfo: {
+                            currencyCode: currency,
+                            totalPriceStatus: 'FINAL',
+                            totalPrice: amount
+                        }
 					};
 				} else {
 					options.card.vault.allowVaultCardOverride = false;

--- a/src/gateways/Gateway.php
+++ b/src/gateways/Gateway.php
@@ -81,6 +81,8 @@ class Gateway extends BaseGateway
 
 	public $privateKey;
 
+    public $googlePayMerchantId;
+
 	public $testMode;
 
 	public $merchantAccountId;
@@ -1082,6 +1084,7 @@ class Gateway extends BaseGateway
 				'vault' => false,
 				'manage' => false,
 				'subscription' => false,
+                'googlePayMerchantId' => $this->googlePayMerchantId,
 			],
 			$params
 		);

--- a/src/templates/gatewaySettings.twig
+++ b/src/templates/gatewaySettings.twig
@@ -16,7 +16,7 @@
 {% from "_includes/forms" import autosuggestField, lightswitchField %}
 
 {{ autosuggestField({
-    label: 'Merchant Id'|t('commerce'),
+    label: 'Merchant ID'|t('commerce'),
     id: 'merchantId',
     class: 'ltr',
     name: 'merchantId',
@@ -48,6 +48,15 @@
 	required: true,
 }) }}
 
+{{ autosuggestField({
+    label: 'Google Pay Merchant ID'|t('commerce'),
+    id: 'googlePayMerchantId',
+    class: 'ltr',
+    name: 'googlePayMerchantId',
+    value: gateway.googlePayMerchantId,
+    errors: gateway.getErrors('googlePayMerchantId'),
+	suggestEnvVars: true,
+}) }}
 
  {{ lightswitchField({
      label: "Test mode?"|t('commerce'),
@@ -63,7 +72,7 @@
 <hr>
 {% for currency in currencies %}
 {{ autosuggestField({
-    label: currency.iso~' Merchant Account Id'|t('commerce'),
+    label: currency.iso~' Merchant Account ID'|t('commerce'),
     class: 'ltr',
     name: 'merchantAccountId['~currency.iso~']',
     value: gateway.merchantAccountId[currency.iso] ?? null,

--- a/src/templates/paymentForms/dropin-ui.twig
+++ b/src/templates/paymentForms/dropin-ui.twig
@@ -6,4 +6,4 @@
 <input type="hidden" name="email" value="{{ order.email }}">
 <input type="hidden" name="address" value="{{ gateway.format3DSAddress(order)|json_encode }}">
 
-<div data-id="dropInUi" {{ gateway.testMode ? 'data-sandbox' }} data-name="{{ storeName ?? siteName }}" data-locale="{{ craft.app.locale().id|replace('-','_') }}" data-subscription="{{ subscription }}" data-threedsecure="{{ threeDSecure }}" data-manage="{{ manage }}" data-translations="{{ (translations ?? null)|json_encode }}"></div>
+<div data-id="dropInUi" {{ gateway.testMode ? 'data-sandbox' }} data-name="{{ storeName ?? siteName }}" data-locale="{{ craft.app.locale().id|replace('-','_') }}" data-subscription="{{ subscription }}" data-threedsecure="{{ threeDSecure }}" data-manage="{{ manage }}" data-translations="{{ (translations ?? null)|json_encode }}" data-googleId="{{ googlePayMerchantId }}"></div>


### PR DESCRIPTION
Currently, when trying to use Google Pay we're getting the console error `DEVELOPER_ERROR in loadPaymentData: transactionInfo must be set!`. This is because the `googlePay` options in `DropinUi.js` are for Apple Pay and don't include the necessary `transactionInfo` object (correct object details [here](https://braintree.github.io/braintree-web-drop-in/docs/current/module-braintree-web-drop-in.html#~googlePayCreateOptions)).

My code changes pull the currency and amount from those variables elsewhere in the script. `totalPriceStatus` is set to `FINAL`, but depending on other plugin users' needs this and other options may need to be configurable on a case-by-case basis. I also added a settings field for `googlePayMerchantId` as this string will need to be passed to `dropin-ui.twig` for production environments.